### PR TITLE
Fix Factory compatibility issue with Lumen < 7

### DIFF
--- a/src/Codeception/Module/Lumen.php
+++ b/src/Codeception/Module/Lumen.php
@@ -587,10 +587,16 @@ class Lumen extends Framework implements ActiveRecord, PartedModule
      */
     protected function modelFactory(string $model, string $name, int $times = 1)
     {
-        if (function_exists('factory')) {
+        if (!function_exists('factory')) {
+            return $model::factory()->count($times);
+        }
+
+        // Support for Lumen < 7 (Factory names defined in illuminate/database version < 7)
+        if (property_exists(FactoryBuilder::class, 'name')) {
             return factory($model, $name, $times);
         }
-        return $model::factory()->count($times);
+        
+        return factory($model, $times);
     }
 
     /**


### PR DESCRIPTION
With illuminate/database version 7 Factory names are removed - more info https://github.com/laravel/framework/pull/30867/

Checking for property `name` ensures that this parameter can be passed.